### PR TITLE
Fix active states

### DIFF
--- a/index.js
+++ b/index.js
@@ -65,8 +65,11 @@ Ymir.prototype.removeView = function( id ) {
     return true;
 };
 
-Ymir.prototype.open = function( id, listItem, e ) {
-    var view;
+Ymir.prototype.open = function( id, e ) {
+    var activeClass = this.options.activeClass || 'active',
+        view,
+        listItems,
+        listItem;
 
     e = e || {};
 
@@ -76,16 +79,21 @@ Ymir.prototype.open = function( id, listItem, e ) {
     e.ymirHandled = true;
 
     if ( id && this.views[ id ] ) {
+
         view = this.views[ id ];
         if ( view.isShown ) {
             return;
         }
-        view.isShown = true;
+
         view.el.classList.add( this.options.showClass );
+        view.isShown = true;
         this._closeViews( id );
-        this.list.children.forEach( Ymir.removeActive );
+
+        listItems = makeArray( this.list.children );
+        listItem = listItems.filter( Ymir.filterById( id ) )[0];
+        listItems.forEach( Ymir.removeActive( activeClass ) );
         if ( listItem ) {
-          listItem.classList.add( 'active' );
+            listItem.classList.add( activeClass );
         }
     }
 };
@@ -111,13 +119,21 @@ Ymir.prototype._appendToList = function( view, el ) {
     var el = document.createElement( this.options.listItemTagName || 'div' );
     el.innerHTML = view.id;
     el.setAttribute( 'data-linkto', view.id );
-    el.addEventListener( 'touchstart', this.open.bind( this, view.id, el ) );
-    el.addEventListener( 'click', this.open.bind( this, view.id, el ) );
+    el.addEventListener( 'touchstart', this.open.bind( this, view.id ) );
+    el.addEventListener( 'click', this.open.bind( this, view.id ) );
     this.list.appendChild( el );
 };
 
-Ymir.removeActive = function( listItem ) {
-    listItem.classList.remove( 'active' );
+Ymir.removeActive = function( activeClass ) {
+    return function( listItem ) {
+        listItem.classList.remove( activeClass );
+    };
+};
+
+Ymir.filterById = function( id ) {
+    return function( listItem ) {
+        return listItem.getAttribute( 'data-linkto' ) === id;
+    };
 };
 
 Ymir.isView = function( view ) {
@@ -127,3 +143,7 @@ Ymir.isView = function( view ) {
         view.el.tagName &&
         view.id; // test all requirements of a view
 };
+
+function makeArray( arr ) {
+    return Array.prototype.slice.call( arr, 0 );
+}

--- a/test/index.js
+++ b/test/index.js
@@ -109,9 +109,26 @@ test( 'testing Ymir::removeView', function( t ) {
 });
 
 test( 'testing Ymir.removeActive', function( t ) {
-    var foo = document.createElement( 'div' );
+    var foo = document.createElement( 'div' ),
+        bar = document.createElement( 'span' );
     foo.classList.add( 'active' );
-    Ymir.removeActive( foo );
-    t.equals( foo.classList.contains( 'active' ), false, 'when Ymir.removeActive is passed a DOM element the active class will be removed from that element' );
+    bar.classList.add( 'active-bar' );
+    t.equals( typeof Ymir.removeActive(), 'function', 'when Ymir.removeActive is called it returns a function or iterator' )
+    Ymir.removeActive( 'active' )( foo );
+    Ymir.removeActive( 'active-bar' )( bar );
+    t.equals( foo.classList.contains( 'active' ), false, 'when Ymir.removeActive return fn is passed a DOM element the class passes in fist argument or intial function will be removed from that element' );
+    t.equals( bar.classList.contains( 'active-bar' ), false, 'when Ymir.removeActive return fn is passed a DOM element the class passes in fist argument or intial function will be removed from that element' );
     t.end();
 });
+
+test( 'testing Ymir.filterById', function( t ) {
+    var foo = document.createElement( 'div' ),
+        bar = foo.cloneNode();
+
+    foo.setAttribute( 'data-linkto', 'baz' );
+    bar.setAttribute( 'data-linkto', 'qux' );
+    t.equals( typeof Ymir.filterById(), 'function', 'when Ymir.filterById is called it returns a function or iterator' );
+    t.equals( Ymir.filterById( 'baz' )( foo ), true, 'when Ymir.filterById return fn is called with a dom node that has an aatribute `data-linkto` thats value is the same as the `id` passed in the initial fn it will return true');
+    t.equals( Ymir.filterById( 'baz' )( bar ), false, 'when Ymir.filterById return fn is called with a dom node that has an aatribute `data-linkto` thats value is differnt then the `id` passed in the initial fn it will return false');    
+    t.end();
+} );


### PR DESCRIPTION
Last merge broke everything, nice one @cardoni lol

This resolves everything as well as being more configurable.

```javascript
new Ymir( { activeClass: 'active-foo' } ); // now list active class will be foo
```